### PR TITLE
print git hash used in accProcess

### DIFF
--- a/accProcess.py
+++ b/accProcess.py
@@ -12,6 +12,7 @@ import accelerometer.summariseEpoch
 import pandas as pd
 import atexit
 import warnings
+import subprocess
 
 
 def main():
@@ -336,6 +337,8 @@ def main():
     # Start processing file
     ##########################
     summary = {}
+    
+    
     # Now process the .CWA file
     if args.processInputFile:
         summary['file-name'] = args.inputFile
@@ -374,6 +377,9 @@ def main():
     # Generate time series file
     accelerometer.accUtils.writeTimeSeries(epochData, labels, args.tsFile)
 
+    # Record git hash used for this processing 
+    summary['git-hash'] = str(subprocess.check_output(["git", "describe"]).strip())
+   
     # Print short summary
     accelerometer.accUtils.toScreen("=== Short summary ===")
     summaryVals = ['file-name', 'file-startTime', 'file-endTime',


### PR DESCRIPTION
A first attempt at printing some of the details of processing as part of the summary. Feedback very welcome! (And please don't merge yet, see below for why). 

TODO: 
- Test in different settings (e.g. installed/non-installed). 
- This only does it for accProcess.py, which means: 1. It doesn't actually tell you which version of accelerometer has been used for different processing (although according to the rules for finding python modules, it should be this one. 2. It doesn't help with any of the other functions in the package (that's a "TODO list" item). 
- The regression test will evidently need updating!
- Probably worth testing for multiple environments as I guess it might be a bit sensitive to that sort of thing. 