### PR TITLE
fix tz for gt3x

### DIFF
--- a/accelerometer/accProcess.py
+++ b/accelerometer/accProcess.py
@@ -43,6 +43,12 @@ def main():  # noqa: C901
                             -15 will shift the device internal time by -15
                             minutes. Not to be confused with timezone offsets.
                             (default : %(default)s""")
+    parser.add_argument('--offsetHour',
+                        metavar='e.g. 00:00:00', default='00:00:00',
+                        type=str, help="""offsetHour is used by GT3X V1 only.
+                        When processing a file not using UTC, make sure 
+                        to specify the hour offset from UTC.
+                            (default : %(default)s""")
     parser.add_argument('--startTime',
                         metavar='e.g. 1991-01-01T23:59', default=None,
                         type=str2date, help="""removes data before this
@@ -304,7 +310,7 @@ def main():  # noqa: C901
         summary['file-name'] = args.inputFile
         accelerometer.device.processInputFileToEpoch(
             args.inputFile, args.timeZone,
-            args.timeShift, args.epochFile, args.stationaryFile, summary,
+            args.timeShift, args.offsetHour, args.epochFile, args.stationaryFile, summary,
             skipCalibration=args.skipCalibration,
             stationaryStd=args.stationaryStd, xyzIntercept=args.calOffset,
             xyzSlope=args.calSlope, xyzSlopeT=args.calTemp,

--- a/accelerometer/device.py
+++ b/accelerometer/device.py
@@ -15,7 +15,7 @@ ROOT_DIR = pathlib.Path(__file__).parent
 
 
 def processInputFileToEpoch(  # noqa: C901
-    inputFile, timeZone, timeShift,
+    inputFile, timeZone, timeShift, offsetHour,
     epochFile, stationaryFile, summary,
     skipCalibration=False, stationaryStd=13, xyzIntercept=[0.0, 0.0, 0.0],
     xyzSlope=[1.0, 1.0, 1.0], xyzSlopeT=[0.0, 0.0, 0.0],
@@ -97,6 +97,7 @@ def processInputFileToEpoch(  # noqa: C901
                            "-XX:ParallelGCThreads=1", rawDataParser, inputFile,
                            "timeZone:" + timeZone,
                            "timeShift:" + str(timeShift),
+                           "offsetHour:" + str(offsetHour),
                            "outputFile:" + stationaryFile,
                            "verbose:" + str(verbose),
                            "filter:" + str(useFilter),
@@ -143,6 +144,7 @@ def processInputFileToEpoch(  # noqa: C901
                        "-XX:ParallelGCThreads=1", rawDataParser, inputFile,
                        "timeZone:" + timeZone,
                        "timeShift:" + str(timeShift),
+                       "offsetHour:" + str(offsetHour),
                        "outputFile:" + epochFile, "verbose:" + str(verbose),
                        "filter:" + str(useFilter),
                        "sampleRate:" + str(sampleRate),

--- a/accelerometer/java/AccelerometerParser.java
+++ b/accelerometer/java/AccelerometerParser.java
@@ -40,6 +40,7 @@ public class AccelerometerParser {
 
         String accFile = ""; // file to process
         String timeZone = "Europe/London";  // file timezone (default: Europe/London)
+        String offsetHour = "00:00:00"; // offset hour for gt3x (default: 00:00:00)
 		String outputFile = ""; // file name for epoch file
 		String rawFile = ""; // file name for epoch file
 		String npyFile = ""; // file name for epoch file
@@ -108,6 +109,8 @@ public class AccelerometerParser {
 					dateFormat.setTimeZone(TimeZone.getTimeZone(timeZone));
 				} else if (funcName.equals("timeShift")) {
 					timeShift = Integer.parseInt(funcParam);
+				} else if (funcName.equals("offsetHour")) {
+					offsetHour = funcParam;
                 } else if (funcName.equals("outputFile")) {
 					outputFile = funcParam;
 				} else if (funcName.equals("verbose")) {
@@ -218,7 +221,8 @@ public class AccelerometerParser {
             } else if (accFile.toLowerCase().endsWith(".bin")) {
 				GENEActivReader.readGeneaEpochs(accFile, epochWriter, verbose);
 			} else if (accFile.toLowerCase().endsWith(".gt3x")) {
-				ActigraphReader.readG3TXEpochs(accFile, timeZone, timeShift, epochWriter, verbose);
+                System.out.println("Make sure to set the offsetHour and timeZone flags for gt3x files");
+				ActigraphReader.readG3TXEpochs(accFile, timeZone, offsetHour, epochWriter, verbose);
 			} else if (accFile.toLowerCase().endsWith(".csv") ||
                         accFile.toLowerCase().endsWith(".csv.gz") ){
 				CsvReader.readCSVEpochs(accFile, epochWriter, csvStartRow,

--- a/accelerometer/java/AccelerometerParser.java
+++ b/accelerometer/java/AccelerometerParser.java
@@ -218,7 +218,7 @@ public class AccelerometerParser {
             } else if (accFile.toLowerCase().endsWith(".bin")) {
 				GENEActivReader.readGeneaEpochs(accFile, epochWriter, verbose);
 			} else if (accFile.toLowerCase().endsWith(".gt3x")) {
-				ActigraphReader.readG3TXEpochs(accFile, epochWriter, verbose);
+				ActigraphReader.readG3TXEpochs(accFile, timeZone, timeShift, epochWriter, verbose);
 			} else if (accFile.toLowerCase().endsWith(".csv") ||
                         accFile.toLowerCase().endsWith(".csv.gz") ){
 				CsvReader.readCSVEpochs(accFile, epochWriter, csvStartRow,

--- a/accelerometer/java/ActigraphReader.java
+++ b/accelerometer/java/ActigraphReader.java
@@ -48,8 +48,12 @@ public class ActigraphReader extends DeviceReader {
      */
     public static void readG3TXEpochs(
         String accFile,
+        String timeZone,
+        int timeShift,
         EpochWriter epochWriter,
         Boolean verbose) {
+
+        setTimeSettings(timeZone, timeShift);
 
         ZipFile zip = null;
         // readers for the 'activity.bin' & 'info.txt' files inside the .zip
@@ -380,7 +384,6 @@ public class ActigraphReader extends DeviceReader {
                     double y = twoSamples[4-twoSampleCounter*3];
                     double z = twoSamples[5-twoSampleCounter*3];
                     double temp = 1.0d; // don't know temp yet
-                    time = getTrueUnixTime(time, infoTimeShift);
                     epochWriter.newValues(time, x, y, z, temp, errCounter);
 
                     samples += 1;
@@ -521,7 +524,6 @@ public class ActigraphReader extends DeviceReader {
                 samples += 1;
 
                 long myTime = Math.round((1000d*samples)/sampleFreq) + firstSampleTime*1000; // in Miliseconds
-                myTime = getTrueUnixTime(myTime, infoTimeShift);
 
                 logger.log(Level.FINER, "i: " + i + "\nx y z: " + sample[0] + " " + sample[1] + " " + sample[2] +
                         "\nTime:" + myTime);


### PR DESCRIPTION
Having spoken with the Actigrpah team, they have confirmed that all the timestamps are stored in UNIX UTC, the true UNIX time. The current expected behaviour is that:

* For npy file, we will just read the timestamps are they are.
* If a user provides the tz flag, we will change the epoch tz to the user input one. Otherwise we will default to `Europe/London`.

This PR should address: issue https://github.com/OxWearables/biobankAccelerometerAnalysis/issues/198