### PR TITLE
Add fix for genea native dst support

### DIFF
--- a/accelerometer/java/AccelerometerParser.java
+++ b/accelerometer/java/AccelerometerParser.java
@@ -215,7 +215,7 @@ public class AccelerometerParser {
 			} else if (accFile.toLowerCase().endsWith(".cwa.gz")) {
                 AxivityReader.readCwaGzEpochs(accFile, timeZone, timeShift, epochWriter, verbose);
             } else if (accFile.toLowerCase().endsWith(".bin")) {
-				GENEActivReader.readGeneaEpochs(accFile, epochWriter, verbose);
+				GENEActivReader.readGeneaEpochs(accFile, timeZone, timeShift, epochWriter, verbose);
 			} else if (accFile.toLowerCase().endsWith(".gt3x")) {
 				ActigraphReader.readG3TXEpochs(accFile, epochWriter, verbose);
 			} else if (accFile.toLowerCase().endsWith(".csv") ||


### PR DESCRIPTION
Currently GENEActive processing doesn't account for timezone or DST. This will create issues when the data was not recored in UTC.

This PR address the issue above by
* Passing `timeZone` to the processing pipeline
* Feed in the corrected timezoned UNIX time to the `newValue` function whose input is the true UNIX time

Test plan:
* Verified with GGIR output is consistent with the current changes
* DST test example
```shell
$ javac -cp accelerometer/java/JTransforms-3.1-with-dependencies.jar accelerometer/java/*.java
$ pip install --editable .
(env_name) hangy@NDPH8334 accelerometer % python accProcess.py ../1.bin 
Processing file '../1.bin' with these arguments:

activityClassification    : True
activityModel             : walmsley
calOffset                 : [0.0, 0.0, 0.0]
calSlope                  : [1.0, 1.0, 1.0]
calTemp                   : [0.0, 0.0, 0.0]
calibrationSphereCriteria : 0.3
csvSampleRate             : None
csvStartRow               : 1
csvStartTime              : None
csvTimeFormat             : yyyy-MM-dd HH:mm:ss.SSSxxxx '['VV']'
csvTimeXYZTempColsIndex   : 0,1,2,3,4
deleteIntermediateFiles   : True
endTime                   : None
epochFile                 : /Users/hangy/biobankAccelerometerAnalysis/1-epoch.csv.gz
epochPeriod               : 30
extractFeatures           : True
fourierFrequency          : False
fourierWithAcc            : False
inputFile                 : ../1.bin
intensityDistribution     : False
m10l5                     : False
meanTemp                  : None
mgCutPointMVPA            : 100
mgCutPointVPA             : 425
nonWearFile               : /Users/hangy/biobankAccelerometerAnalysis/1-nonWearBouts.csv.gz
npyFile                   : /Users/hangy/biobankAccelerometerAnalysis/1.npy
npyOutput                 : False
outputFolder              : /Users/hangy/biobankAccelerometerAnalysis
processInputFile          : True
psd                       : False
rawDataParser             : AccelerometerParser
rawFile                   : /Users/hangy/biobankAccelerometerAnalysis/1.csv.gz
rawOutput                 : False
resampleMethod            : linear
sampleRate                : 100
skipCalibration           : False
startTime                 : None
stationaryFile            : /Users/hangy/biobankAccelerometerAnalysis/1-stationaryPoints.csv.gz
stationaryStd             : 13
summaryFile               : /Users/hangy/biobankAccelerometerAnalysis/1-summary.json
timeSeriesDateColumn      : False
timeShift                 : 0
timeZone                  : Europe/London
tsFile                    : /Users/hangy/biobankAccelerometerAnalysis/1-timeSeries.csv.gz
useFilter                 : True
verbose                   : False

2022-09-27 11:44:06	=== Calibrating ===
Intermediate file: /Users/hangy/biobankAccelerometerAnalysis/1-stationaryPoints.csv.gz
Device was programmed with delayed start time
Session start: 2013-06-10T19:30:00.500+01:00[Europe/London]

2022-09-27 11:44:13	=== Extracting features ===
Intermediate file: /Users/hangy/biobankAccelerometerAnalysis/1-epoch.csv.gz
Device was programmed with delayed start time
Session start: 2013-06-10T19:30:00.500+01:00[Europe/London]

2022-09-27 11:44:34	=== Summarizing ===
Downloading https://wearables-files.ndph.ox.ac.uk/files/models/10Feb2022/walmsley/model.tar...
0 rows with NaN or Inf values, out of 1439

2022-09-27 11:45:03	=== Short summary ===
{
    "file-name": "../1.bin",
    "file-startTime": "2013-06-10 19:30:00.500000+0100 [Europe/London]",
    "file-endTime": "2013-06-11 07:29:00.500000+0100 [Europe/London]",
    "acc-overall-avg": 4.29104,
    "wearTime-overall(days)": 0.5,
    "nonWearTime-overall(days)": 0.0,
    "quality-goodWearTime": 0
}
Full summary written to: /Users/hangy/biobankAccelerometerAnalysis/1-summary.json

2022-09-27 11:45:03	In total, processing took 57.192051 seconds
````

Test file is from a sample Newcastle file `/well/doherty/projects/newcastle_psg/acc/1.bin`

Original acc plot
![1_bbaa](https://user-images.githubusercontent.com/7655454/192506438-ca586d19-0dea-4feb-a9ed-7f8f6b52a756.png)

New acc plot with time zone and DST 
![1-timeSeries-plot](https://user-images.githubusercontent.com/7655454/192506627-8eb2d20d-9cc9-4619-bbe0-64a0cc66805f.png)

The introduced change correctly move the time series forward by one hour in the summer. The the class prediction might be different possibly due to that the original plot was using an older version of bbaa. Based on the PSG data, this subject was awake around 07:30 which is consistent with the new processing. R stands for REM sleep and W stands for wake.

![Screenshot 2022-09-27 at 15 38 50](https://user-images.githubusercontent.com/7655454/192557187-b084c34b-e89a-4019-9a4e-ca489ee8b063.png)


Disclaimer: Couldn't do a PR from my fork because my fork master has some important changes with the upstream doesn't have.
 
Resolves https://github.com/OxWearables/biobankAccelerometerAnalysis/issues/203

Please could you review ASAP because I am blocked by the Geneactive data processing to retrain the model. Thank you :D 