### PR TITLE
Update sklearn to 1.0.2 to fix install issue in Python 3.10 due to Cython upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setuptools.setup(
         'statsmodels==0.13.*',
         'joblib==1.1.*',
         'imbalanced-learn==0.8.1',
-        'scikit-learn==1.0.1',
+        'scikit-learn==1.0.2',
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Recent Cython upgrade breaks scikit-learn installation for Python 3.10. This was fixed in scikit-learn==1.0.2