### PR TITLE
Update models after scikit-learn==1.0.2

### DIFF
--- a/src/accelerometer/models.py
+++ b/src/accelerometer/models.py
@@ -7,29 +7,28 @@ MODEL_ROOT_URL = "https://wearables-files.ndph.ox.ac.uk/files/models/biobankAcce
 MODELS = {
 
     'willetts': {
-        "pth": MODEL_DIR / "willetts" / "20220210.tar",
-        "url": f"{MODEL_ROOT_URL}/willetts/20220210.tar",
+        "pth": MODEL_DIR / "willetts" / "20220210_sk_1_0_2.tar",
+        "url": f"{MODEL_ROOT_URL}/willetts/20220210_sk_1_0_2.tar",
     },
 
     'doherty': {
-        "pth": MODEL_DIR / "doherty" / "20220210.tar",
-        "url": f"{MODEL_ROOT_URL}/doherty/20220210.tar",
+        "pth": MODEL_DIR / "doherty" / "20220210_sk_1_0_2.tar",
+        "url": f"{MODEL_ROOT_URL}/doherty/20220210_sk_1_0_2.tar",
     },
 
     'walmsley': {
-        "pth": MODEL_DIR / "walmsley" / "20220210.tar",
-        "url": f"{MODEL_ROOT_URL}/walmsley/20220210.tar",
+        "pth": MODEL_DIR / "walmsley" / "20220210_sk_1_0_2.tar",
+        "url": f"{MODEL_ROOT_URL}/walmsley/20220210_sk_1_0_2.tar",
     },
 
     'chan': {
-        "pth": MODEL_DIR / "chan" / "20230103.tar",
-        "url": f"{MODEL_ROOT_URL}/chan/20230103.tar",
-
+        "pth": MODEL_DIR / "chan" / "20230103_sk_1_0_2.tar",
+        "url": f"{MODEL_ROOT_URL}/chan/20230103_sk_1_0_2.tar",
     },
 
     'chanw': {
-        "pth": MODEL_DIR / "chanw" / "20230106.tar",
-        "url": f"{MODEL_ROOT_URL}/chanw/20230106.tar"
+        "pth": MODEL_DIR / "chanw" / "20230106_sk_1_0_2.tar",
+        "url": f"{MODEL_ROOT_URL}/chanw/20230106_sk_1_0_2.tar"
     },
 
 }


### PR DESCRIPTION
Re-pickle models after recent scikit-learn update to 1.0.2 to omit warning.