### PR TITLE
ci: update GitHub Actions workflow to exclude Python 3.7 on macOS latest

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -15,6 +15,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        # https://github.com/actions/runner-images/issues/9770#issuecomment-2085623315
+        exclude:  # Python < v3.8 does not support Apple Silicon ARM64.
+          - python-version: "3.7"
+            os: macos-latest
+        include:  # So run those legacy versions on Intel CPUs.
+          - python-version: "3.7"
+            os: macos-13
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This change is made to address the issue where Python < v3.8 does not support Apple Silicon ARM64. As a result, the legacy versions of Python 3.7 will only be run on Intel CPUs.