### PR TITLE
ci: update Ubuntu version to 22.04 for Python 3.7 workflows

### DIFF
--- a/.github/workflows/cwa.yml
+++ b/.github/workflows/cwa.yml
@@ -19,7 +19,7 @@ jobs:
           - python-version: "3.7"
         include:  # use older ubuntu for python 3.7
           - python-version: "3.7"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -24,7 +24,7 @@ jobs:
             os: macos-13
           # use older ubuntu for python 3.7
           - python-version: "3.7"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the operating system version used in GitHub Actions workflows, replacing `ubuntu-20.04` with `ubuntu-22.04` for Python 3.7 jobs.

Updates to GitHub Actions workflows:

* [`.github/workflows/cwa.yml`](diffhunk://#diff-4ad3042b4b9cff440403680b62ff8010c13785d5887ef6c76dda3bb83db135ecL22-R22): Updated the `os` field for Python 3.7 jobs from `ubuntu-20.04` to `ubuntu-22.04`.
* [`.github/workflows/install.yml`](diffhunk://#diff-1f5b844aa5fb28f676b2210fcb7e47db8a5c995374272cbe93352ff41b4ddb21L27-R27): Updated the `os` field for Python 3.7 jobs from `ubuntu-20.04` to `ubuntu-22.04`.